### PR TITLE
New docker-compose to deploy application on local network

### DIFF
--- a/docker-compose.local.dev.yml
+++ b/docker-compose.local.dev.yml
@@ -1,11 +1,5 @@
 version: '3'
 
-networks:
-  apps:
-    driver: bridge
-  db:
-    driver: bridge
-
 volumes:
   pg-data:
   pgadmin-data:
@@ -20,10 +14,10 @@ services:
     environment:
       - |
         JAVA_TOOL_OPTIONS=
-        -Dpostservice.url=http://postservice:8081
-        -Dauthenticationservice.url=http://authenticationservice:8082
-        -Dcommentservice.url=http://commentservice:8083
-        -Dclientservice.url=http://clientservice:8085
+        -Dpostservice.url=http://localhost:8081
+        -Dauthenticationservice.url=http://localhost:8082
+        -Dcommentservice.url=http://localhost:8083
+        -Dclientservice.url=http://localhost:8085
 
   bulletin-buddy-post-service:
     image: ase/bulletin-post-service

--- a/docker-compose.local.dev.yml
+++ b/docker-compose.local.dev.yml
@@ -17,7 +17,7 @@ services:
         -Dpostservice.url=http://localhost:8081
         -Dauthenticationservice.url=http://localhost:8082
         -Dcommentservice.url=http://localhost:8083
-        -Dclientservice.url=http://localhost:8085
+        -Dclientservice.url=http://localhost:4200
 
   bulletin-buddy-post-service:
     image: ase/bulletin-post-service

--- a/docker-compose.local.dev.yml
+++ b/docker-compose.local.dev.yml
@@ -1,0 +1,84 @@
+version: '3'
+
+networks:
+  apps:
+    driver: bridge
+  db:
+    driver: bridge
+
+volumes:
+  pg-data:
+  pgadmin-data:
+
+services:
+
+  gateway:
+    image: ase/bulletin-gateway
+    build: bulletin-buddy-gateway
+    container_name: gateway
+    network_mode: "host"
+    environment:
+      - |
+        JAVA_TOOL_OPTIONS=
+        -Dpostservice.url=http://postservice:8081
+        -Dauthenticationservice.url=http://authenticationservice:8082
+        -Dcommentservice.url=http://commentservice:8083
+        -Dclientservice.url=http://clientservice:8085
+
+  bulletin-buddy-post-service:
+    image: ase/bulletin-post-service
+    build: bulletin-buddy-post-service
+    container_name: post-service
+    network_mode: "host"
+    hostname: postservice
+    restart: on-failure
+    depends_on:
+      - db
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5433/postgres_db
+      - SPRING_DATASOURCE_USERNAME=root
+      - SPRING_DATASOURCE_PASSWORD=root
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=update
+      - SPRING_JPA_HIBERNATE_DDL=false
+
+  bulletin-buddy-authentication-service:
+    image: ase/bulletin-authentication-service
+    build: bulletin-buddy-authentication-service
+    container_name: authentication-service
+    network_mode: "host"
+    hostname: authenticationservice
+    restart: on-failure
+
+  bulletin-buddy-comment-service:
+    image: ase/bulletin-comment-service
+    build: bulletin-buddy-comment-service
+    container_name: comment-service
+    hostname: commentservice
+    network_mode: "host"
+    restart: on-failure
+    depends_on:
+      - db
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5433/postgres_db
+      - SPRING_DATASOURCE_USERNAME=root
+      - SPRING_DATASOURCE_PASSWORD=root
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=update
+      - SPRING_JPA_HIBERNATE_DDL=false
+
+  db:
+    image: postgres
+    container_name: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: root
+      POSTGRES_DB: postgres_db
+      PGDATA: /var/lib/postgresql/data
+    expose:
+      - "5433"
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+      - ./sql/create_tables.sql:/docker-entrypoint-initdb.d/create_tables.sql
+      - ./sql/fill_tables.sql:/docker-entrypoint-initdb.d/fill_tables.sql
+    command: -p 5433
+    network_mode: "host"


### PR DESCRIPTION
This docker compose (docker-compose.local.dev.yml) was added to address issues that some team members were having with developing the frontend module with the live changes features. In order to fix the issue, all backend services now map directly to the localhost ports instead of using a separate Docker network.

**NOTE**: if you have services already running on those ports (either background services or containers mapped to those ports)  you should change to something else, or they will clash and the deployment will not work. (example: if port 8080 is already taken, consider using a port number like 30080 to avoid the clash)